### PR TITLE
Update MelodyMaker.control.js

### DIFF
--- a/ControllerScripts/MelodyMaker.control.js
+++ b/ControllerScripts/MelodyMaker.control.js
@@ -1,3 +1,5 @@
+loadAPI(17)
+
 /**
  * Melody Maker
  * controller script for Bitwig Studio
@@ -5,7 +7,7 @@
  * @version 0.1
  * @author Polarity
  */
-loadAPI(17)
+
 host.setShouldFailOnDeprecatedUse(true)
 host.defineController('Polarity', 'Melody Maker', '0.1', '1f73b4d7-0cfe-49e6-bf70-f7191bdb3a24', 'Polarity')
 


### PR DESCRIPTION
loadAPI() must be in the first row for proper Bitwig detection!

Tested on BW 5.3b8