### PR TITLE
add bitwig api types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 desktop.ini
+node_modules

--- a/ControllerScripts/ScaleMaker.control.js
+++ b/ControllerScripts/ScaleMaker.control.js
@@ -13,7 +13,12 @@ host.defineController('Polarity', 'Scale Maker', '0.1', 'b3f52fc6-e887-4bb6-927a
 // Define the dropdown options for the UI
 const listScale = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
 const booleanOption = ['No', 'Yes']
-let scaleIntervals
+
+/**
+ * will be filled in with scales from external file
+ * @type {{[key: string]: number[]}}
+ */
+let scaleIntervals = {}
 
 // load in the external scales.js file
 load('scales.js')
@@ -39,7 +44,10 @@ if (!scaleIntervals || Object.keys(scaleIntervals).length === 0) {
 // we need this for the dropdown in the UI
 const listScaleMode = Object.keys(scaleIntervals)
 
-// Store the current notes in the clip
+/**
+ * Store the current notes in the clip
+ * @type {Array<number[]>}
+ */
 const currentNotesInClip = []
 
 /**
@@ -162,7 +170,7 @@ function generateDirectionalNotes (notes, startNote, intervals, direction) {
  * for C minor, we want to move C# to D, not to C etc.
  * @param {*} y - note to find closest higher and lower notes
  * @param {*} scaleNotes - array of notes in the scale
- * @returns {Object} - object with lower and higher notes
+ * @returns {{lower: number, higher: number}} - object with lower and higher notes
  */
 function findClosestHigherAndLower (y, scaleNotes) {
   let low = 0; let high = scaleNotes.length - 1
@@ -335,7 +343,7 @@ function init () {
 
   /**
    * get the correct cursor clip based on the selected clip type
-   * @returns {CursorClip} - the cursor clip based on the selected clip type
+   * @returns the cursor clip based on the selected clip type
    */
   function getCursorClip () {
     if (clipType.get() === 'Arranger') {

--- a/ControllerScripts/scales.js
+++ b/ControllerScripts/scales.js
@@ -1,3 +1,4 @@
+// @ts-ignore
 scaleIntervals = {
   Lydian: [2, 2, 2, 1, 2, 2, 1], // Major scale with raised 4th
   Major: [2, 2, 1, 2, 2, 2, 1], // Major scale

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "polarity-music-tools",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "polarity-music-tools",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typed-bitwig-api": "^19.0.0",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/typed-bitwig-api": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/typed-bitwig-api/-/typed-bitwig-api-19.0.0.tgz",
+      "integrity": "sha512-O3jo/uH91tJQUezcvkSP5sZxw1nM4BsKcQDhlzI7EziaHWQT5F/JsbNT1aHxfkmUjD+EON/AAjZeeYQ+NgY6ww==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "polarity-music-tools",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typed-bitwig-api": "^19.0.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "checkJs": true,
+        "outDir": "./dummy",
+        "lib": ["ES2024"],
+        "types": ["typed-bitwig-api"],
+        "moduleDetection": "force",
+        "strict": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noUnusedParameters": true,
+    },
+    "include": ["ControllerScripts/**/*.js"],
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
this allows type checking and autocomplete in editors like VSCode:

![Screenshot 2025-04-06 at 16 09 10](https://github.com/user-attachments/assets/8f1714a1-18f5-4959-aab8-5b766948bee9)

![Screenshot 2025-04-06 at 16 09 28](https://github.com/user-attachments/assets/01c6d84b-688c-4498-9e4e-fcbad150a71d)

![Screenshot 2025-04-06 at 16 07 21](https://github.com/user-attachments/assets/c107a5df-f30c-4fda-a115-151530080fd5)

don't forget to `npm install`.

you can also do type checking in the terminal: `npm run lint`.

i also added jsdoc types where necessary to fix type errors.

big thanks to @joslarson for his published bitwig api js types, see https://github.com/joslarson/typed-bitwig-api